### PR TITLE
Add sample dashboard data and soften payload handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ config.json
 mlb-simmer/*
 venv/*
 dk_data/*
+!dk_data/projections.csv
 fd_data/*
+!fd_data/projections.csv

--- a/dk_data/.gitignore
+++ b/dk_data/.gitignore
@@ -2,3 +2,5 @@
 *
 # Except this file
 !.gitignore
+# Allow committed representative projection data
+!projections.csv

--- a/dk_data/projections.csv
+++ b/dk_data/projections.csv
@@ -1,0 +1,6 @@
+Name,Team,Pos,Fpts,Own%
+Shohei Ohtani,LAD,OF,12.5,24.1
+Ronald Acuna Jr.,ATL,OF,11.8,18.3
+Juan Soto,NYY,OF,10.9,15.7
+Austin Riley,ATL,3B,9.4,12.5
+Corey Seager,TEX,SS,9.1,10.2

--- a/fd_data/.gitignore
+++ b/fd_data/.gitignore
@@ -2,3 +2,5 @@
 *
 # Except this file
 !.gitignore
+# Allow committed representative projection data
+!projections.csv

--- a/fd_data/projections.csv
+++ b/fd_data/projections.csv
@@ -1,0 +1,6 @@
+Name,Team,Pos,Fpts,Own%
+Aaron Judge,NYY,OF,14.2,22.0
+Mookie Betts,LAD,2B/OF,13.1,19.4
+Matt Olson,ATL,1B,12.6,16.8
+Fernando Tatis Jr.,SD,OF,11.7,14.9
+Julio Rodriguez,SEA,OF,10.5,11.3

--- a/output/.gitignore
+++ b/output/.gitignore
@@ -2,3 +2,7 @@
 *
 # Except this file
 !.gitignore
+# Allow representative dashboard artefacts
+!dk_optimal_lineups_*.csv
+!dk_gpp_sim_lineups_*.csv
+!dk_gpp_sim_player_exposure_*.csv

--- a/output/dk_gpp_sim_lineups_20_500.csv
+++ b/output/dk_gpp_sim_lineups_20_500.csv
@@ -1,0 +1,4 @@
+P,C,1B,2B,3B,SS,OF1,OF2,OF3,FLEX,FPTS Proj,Ceiling,Win %,Top 10%,ROI%,Avg. Return,Stack 1,Stack 2
+Tyler Glasnow,Will Smith,Matt Olson,Ozzie Albies,Austin Riley,Corey Seager,Ronald Acuna Jr.,Juan Soto,Shohei Ohtani,Freddie Freeman,142.3,178.4,12.5%,34.6%,18.2%,$450.00,ATL 4,LAD 3
+Corbin Burnes,Adley Rutschman,Vladimir Guerrero Jr.,Marcus Semien,Rafael Devers,Bobby Witt Jr.,Kyle Tucker,Julio Rodriguez,Mookie Betts,Yordan Alvarez,138.6,171.3,10.8%,31.2%,15.7%,$380.00,BOS 3,HOU 3
+Zack Wheeler,J.T. Realmuto,Bryce Harper,Trea Turner,Alec Bohm,Xander Bogaerts,Kyle Schwarber,Luis Robert Jr.,Fernando Tatis Jr.,Juan Soto,136.1,168.0,9.7%,28.4%,13.9%,$325.00,PHI 4,SD 3

--- a/output/dk_gpp_sim_player_exposure_20_500.csv
+++ b/output/dk_gpp_sim_player_exposure_20_500.csv
@@ -1,0 +1,11 @@
+Player,Pos,Team,Sim Own%,Proj Own%,Win%,Top1%,Cash%
+Shohei Ohtani,OF,LAD,32.4%,28.5%,14.2%,7.8%,52.1%
+Ronald Acuna Jr.,OF,ATL,30.1%,24.6%,13.5%,6.9%,48.3%
+Juan Soto,OF,NYY,26.7%,22.3%,11.9%,6.1%,45.0%
+Corey Seager,SS,TEX,24.4%,18.5%,10.8%,5.7%,41.2%
+Freddie Freeman,1B,LAD,21.5%,17.1%,9.4%,4.9%,38.7%
+Tyler Glasnow,P,LAD,18.2%,15.3%,8.7%,4.2%,35.4%
+Austin Riley,3B,ATL,17.8%,14.9%,8.1%,3.9%,33.2%
+Matt Olson,1B,ATL,16.4%,12.8%,7.6%,3.5%,31.7%
+Ozzie Albies,2B,ATL,15.7%,11.5%,7.0%,3.2%,30.1%
+Will Smith,C,LAD,14.9%,10.9%,6.3%,2.8%,28.4%

--- a/output/dk_optimal_lineups_2024-04-01.csv
+++ b/output/dk_optimal_lineups_2024-04-01.csv
@@ -1,0 +1,3 @@
+P,C,1B,2B,3B,SS,OF1,OF2,OF3,FLEX,Salary,FPTS Proj
+Tyler Glasnow,Will Smith,Matt Olson,Ozzie Albies,Austin Riley,Corey Seager,Ronald Acuna Jr.,Juan Soto,Shohei Ohtani,Freddie Freeman,49900,142.3
+Corbin Burnes,Adley Rutschman,Vladimir Guerrero Jr.,Marcus Semien,Rafael Devers,Bobby Witt Jr.,Kyle Tucker,Julio Rodriguez,Mookie Betts,Yordan Alvarez,49750,138.6

--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -529,11 +529,11 @@ def build_dashboard_payload(site: str) -> Dict[str, object]:
     sim_lineups, sim_info = _load_simulation_lineups(site)
     exposure_df, exposure_info = _load_simulation_exposure(site)
 
-    if all(
-        dataset is None or (hasattr(dataset, "empty") and dataset.empty)
-        for dataset in (projections_df, optimizer_df, sim_lineups, exposure_df)
-    ):
-        raise HTTPException(status_code=404, detail="No dashboard data found for the requested site.")
+    datasets = (projections_df, optimizer_df, sim_lineups, exposure_df)
+    has_data = any(
+        dataset is not None and not (hasattr(dataset, "empty") and dataset.empty)
+        for dataset in datasets
+    )
 
     payload: Dict[str, object] = {
         "site": site,
@@ -558,8 +558,10 @@ def build_dashboard_payload(site: str) -> Dict[str, object]:
             "simulation": _format_timestamp(sim_info),
             "playerExposure": _format_timestamp(exposure_info),
         },
+        "hasData": has_data,
     }
 
+    payload["projectionSample"] = []
     if projections_df is not None and not projections_df.empty:
         sample_columns = [col for col in ["name", "team", "pos", "fpts", "own%"] if col in projections_df.columns]
         if sample_columns:


### PR DESCRIPTION
## Summary
- commit representative projection and simulation CSVs so the dashboard API has seed data on start
- update ignore rules to allow the committed artefacts to live in version control
- let `build_dashboard_payload` return empty structures (with a `hasData` flag) instead of a 404 when files are missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdb15ca6b4832e9e478976b5be9ddd